### PR TITLE
Initial support for converting angular bit to radians

### DIFF
--- a/src/device/xl330.rs
+++ b/src/device/xl330.rs
@@ -73,3 +73,26 @@ reg_read_write!(indirect_data_3, 226, u8);
 reg_read_write!(indirect_data_4, 227, u8);
 reg_read_write!(indirect_data_5, 228, u8);
 reg_read_write!(indirect_data_6, 229, u8);
+
+/// Unit conversion for XL-330 motors
+pub mod conv {
+    /// Dynamixel angular position to radians
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn pos_to_radians(pos: u32) -> f64 {
+        (360.0_f64.to_radians() * (pos as f64) / 4096.0) - 180.0_f64.to_radians()
+    }
+    /// Radians to dynamixel angular position
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn radians_to_pos(rads: f64) -> u32 {
+        (4096.0 * (180.0_f64.to_radians() + rads) / 360.0_f64.to_radians()) as u32
+    }
+    /// Dynamixel angular velocity to radians per second
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn abs_speed_to_rad_per_sec(speed: u32) -> f64 {
+        let rpm = speed as f64 * 0.229;
+        rpm * 0.10472
+    }
+}

--- a/src/device/xl430.rs
+++ b/src/device/xl430.rs
@@ -72,3 +72,26 @@ reg_read_write!(indirect_data_3, 226, u8);
 reg_read_write!(indirect_data_4, 227, u8);
 reg_read_write!(indirect_data_5, 228, u8);
 reg_read_write!(indirect_data_6, 229, u8);
+
+/// Unit conversion for XL-430 motors
+pub mod conv {
+    /// Dynamixel angular position to radians
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn pos_to_radians(pos: u32) -> f64 {
+        (360.0_f64.to_radians() * (pos as f64) / 4096.0) - 180.0_f64.to_radians()
+    }
+    /// Radians to dynamixel angular position
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn radians_to_pos(rads: f64) -> u32 {
+        (4096.0 * (180.0_f64.to_radians() + rads) / 360.0_f64.to_radians()) as u32
+    }
+    /// Dynamixel angular velocity to radians per second
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn abs_speed_to_rad_per_sec(speed: u32) -> f64 {
+        let rpm = speed as f64 * 0.229;
+        rpm * 0.10472
+    }
+}

--- a/src/device/xm.rs
+++ b/src/device/xm.rs
@@ -1,11 +1,9 @@
 //! MX robotis register (protocol v1)
 //!
 //! Despite some minor differences among MX variants, it should work for
-//! * MX-28
-//! * MX-64
-//! * MX-106
+//! * XM430-W350
 //!
-//! See <https://emanual.robotis.com/docs/en/dxl/mx/mx-28/> for example.
+//! See <chttps://emanual.robotis.com/docs/en/dxl/xm/xm430-w350/> for example.
 
 use crate::device::*;
 
@@ -53,10 +51,56 @@ reg_read_only!(realtime_tick, 120, u16);
 reg_read_only!(moving, 122, u8);
 reg_read_only!(moving_status, 123, u8);
 reg_read_only!(present_pwm, 124, u16);
-reg_read_only!(present_load, 126, u16);
+reg_read_only!(present_current, 126, u16);
 reg_read_only!(present_velocity, 128, u32);
 reg_read_only!(present_position, 132, u32);
 reg_read_only!(velocity_trajectory, 136, u32);
 reg_read_only!(position_trajectory, 140, u32);
 reg_read_only!(present_input_voltage, 144, u16);
 reg_read_only!(present_temperature, 146, u8);
+
+/// Sync read present_position, present_speed and present_current in one message
+///
+/// reg_read_only!(present_position_speed_current, 36, (i16, u16, u16))
+pub fn sync_read_present_position_speed_load(
+    io: &DynamixelSerialIO,
+    serial_port: &mut dyn serialport::SerialPort,
+    ids: &[u8],
+) -> Result<Vec<(u32, u32, u16)>> {
+    let val = io.sync_read(serial_port, ids, 126, 2 + 4 + 4)?;
+    let val = val
+        .iter()
+        .map(|v| {
+            (
+                u32::from_le_bytes(v[6..10].try_into().unwrap()),
+                u32::from_le_bytes(v[2..6].try_into().unwrap()),
+                u16::from_le_bytes(v[0..2].try_into().unwrap()),
+            )
+        })
+        .collect();
+
+    Ok(val)
+}
+
+/// Unit conversion for XL-320 motors
+pub mod conv {
+    /// Dynamixel angular position to radians
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn pos_to_radians(pos: u32) -> f64 {
+        (360.0_f64.to_radians() * (pos as f64) / 4096.0) - 180.0_f64.to_radians()
+    }
+    /// Radians to dynamixel angular position
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn radians_to_pos(rads: f64) -> u32 {
+        (4096.0 * (180.0_f64.to_radians() + rads) / 360.0_f64.to_radians()) as u32
+    }
+    /// Dynamixel angular velocity to radians per second
+    ///
+    /// Works in joint and multi-turn mode
+    pub fn abs_speed_to_rad_per_sec(speed: u32) -> f64 {
+        let rpm = speed as f64 * 0.229;
+        rpm * 0.10472
+    }
+}


### PR DESCRIPTION
Initial support for converting angular bit to radians.

This can later become generics as it only depends on the data size.